### PR TITLE
Adds support for ActionPack 4.2

### DIFF
--- a/lib/rails/info_controller.rb
+++ b/lib/rails/info_controller.rb
@@ -11,8 +11,8 @@ class Rails::InfoController < Rails::ApplicationController # :nodoc:
     grape_klasses.each do |klass|
       klass.compile
       klass.routes.each do |route|
-        path = ActionDispatch::Journey::Path::Pattern.new route.route_path
-        all_routes.add_route(klass, path, {
+        path = ActionDispatch::Journey::Path::Pattern.from_string route.route_path
+        all_routes.add_route(app, path, {
           request_method: %r{^#{route.route_method}$}
         }, {}, route.route_description)
       end

--- a/lib/rails/routes_with_grape.rb
+++ b/lib/rails/routes_with_grape.rb
@@ -1,0 +1,27 @@
+module RoutesWithGrape
+
+  def append_grape_to(rails_routes)
+    all_routes = rails_routes.routes
+    grape_klasses = ObjectSpace.each_object(Class).select { |klass| klass < Grape::API }
+    app = all_routes.first.app
+    grape_klasses.each do |klass|
+      klass.compile
+      klass.routes.each do |route|
+        # Rails 4.2+
+        if ActionDispatch::Journey::Path::Pattern.respond_to?(:from_string)
+          path = ActionDispatch::Journey::Path::Pattern.from_string route.route_path
+          all_routes.add_route(app, path, {
+            request_method: %r{^#{route.route_method}$}
+          }, {}, route.route_description)
+        else
+          path = ActionDispatch::Journey::Path::Pattern.new route.route_path
+          all_routes.add_route(klass, path, {
+            request_method: %r{^#{route.route_method}$}
+          }, {}, route.route_description)
+        end
+      end
+    end
+    all_routes
+  end
+
+end

--- a/lib/rails/tasks/routes_with_grape.rake
+++ b/lib/rails/tasks/routes_with_grape.rake
@@ -1,18 +1,8 @@
 desc 'Print out all defined routes, with grape routes, in match order, with names. Target specific controller with CONTROLLER=x.'
 task routes_with_grape: :environment do
-  all_routes = Rails.application.routes.routes
-  grape_klasses = ObjectSpace.each_object(Class).select { |klass| klass < Grape::API }
-  app = all_routes.first.app
-  grape_klasses.each do |klass|
-    klass.compile
-    klass.routes.each do |route|
-      path = ActionDispatch::Journey::Path::Pattern.from_string route.route_path
-      all_routes.add_route(app, path, {
-        request_method: %r{^#{route.route_method}$}
-      }, {}, route.route_description)
-    end
-  end
   require 'action_dispatch/routing/inspector'
-  inspector = ActionDispatch::Routing::RoutesInspector.new(all_routes)
+  require 'rails/routes_with_grape'
+  include RoutesWithGrape
+  inspector = ActionDispatch::Routing::RoutesInspector.new(append_grape_to(Rails.application.routes))
   puts inspector.format(ActionDispatch::Routing::ConsoleFormatter.new, ENV['CONTROLLER'])
 end

--- a/lib/rails/tasks/routes_with_grape.rake
+++ b/lib/rails/tasks/routes_with_grape.rake
@@ -6,8 +6,8 @@ task routes_with_grape: :environment do
   grape_klasses.each do |klass|
     klass.compile
     klass.routes.each do |route|
-      path = ActionDispatch::Journey::Path::Pattern.new route.route_path
-      all_routes.add_route(klass, path, {
+      path = ActionDispatch::Journey::Path::Pattern.from_string route.route_path
+      all_routes.add_route(app, path, {
         request_method: %r{^#{route.route_method}$}
       }, {}, route.route_description)
     end


### PR DESCRIPTION
Fixes #2 

`ActionDispatch::Journey::Path::Pattern.from_string` is now used to get the `path` and `#add_route` takes `app` instead of `klass`

```
path = ActionDispatch::Journey::Path::Pattern.from_string route.route_path
  all_routes.add_route(app, path, {
    request_method: %r{^#{route.route_method}$}
  }, {}, route.route_description)
```

Unfortunately didn't have time to figure out how to prevent the `app` from being dumped to the output
